### PR TITLE
Fix inline jumps

### DIFF
--- a/include/config.h.in
+++ b/include/config.h.in
@@ -22,6 +22,9 @@
 /* Define as 1 if you want to compile each Scheme file into one C function.  */
 #undef ___SINGLE_HOST
 
+/* Define as 1 if jumps in code should be emitted inline.  */
+#undef ___INLINE_JUMPS
+
 /* Define as 1 if you want to compile as a shared library.  */
 #undef ___SHARED
 

--- a/include/gambit.h.in
+++ b/include/gambit.h.in
@@ -3748,7 +3748,7 @@ goto *___LABEL_HOST_LABEL(___pc);
 
 #define ___DEF_SW(n)
 
-#ifdef ___USE_INLINE_JUMPS
+#ifdef ___INLINE_JUMPS
 
 #define ___END_SW \
 ___jumpext:


### PR DESCRIPTION
The cpp define for inline jumps was misspelled in gambit.h.in and
completely gone from config.h.in