### PR TITLE
Default character encoding for file paths is UTF-8.

### DIFF
--- a/lib/os.c
+++ b/lib/os.c
@@ -1685,14 +1685,12 @@ ___SCMOBJ modification_time;)
 
 #ifdef USE_utimes
 
-#define ___TIMES_PATH_CE_SELECT(latin1,utf8,ucs2,ucs4,wchar,native) native
-
   if ((e = ___SCMOBJ_to_NONNULLSTRING
              (___PSA(___PSTATE)
               path,
               &cpath,
               1,
-              ___CE(___TIMES_PATH_CE_SELECT),
+              ___CE(___PATH_CE_SELECT),
               0))
       == ___FIX(___NO_ERR))
     {
@@ -1701,7 +1699,7 @@ ___SCMOBJ modification_time;)
       ___absolute_time_to_timeval (atime, &tv[0]);
       ___absolute_time_to_timeval (mtime, &tv[1]);
 
-      if (utimes (___CAST(___STRING_TYPE(___TIMES_PATH_CE_SELECT),cpath), tv)
+      if (utimes (___CAST(___STRING_TYPE(___PATH_CE_SELECT),cpath), tv)
           < 0)
         {
           e = fnf_or_err_code_from_errno ();
@@ -1716,18 +1714,12 @@ ___SCMOBJ modification_time;)
 
 #ifdef USE_SetFileTime
 
-#ifdef _UNICODE
-#define ___TIMES_PATH_CE_SELECT(latin1,utf8,ucs2,ucs4,wchar,native) ucs2
-#else
-#define ___TIMES_PATH_CE_SELECT(latin1,utf8,ucs2,ucs4,wchar,native) native
-#endif
-
   if ((e = ___SCMOBJ_to_NONNULLSTRING
              (___PSA(___PSTATE)
               path,
               &cpath,
               1,
-              ___CE(___TIMES_PATH_CE_SELECT),
+              ___CE(___PATH_CE_SELECT),
               0))
       == ___FIX(___NO_ERR))
     {
@@ -1737,7 +1729,7 @@ ___SCMOBJ modification_time;)
       ___time_to_FILETIME (atime, &ft[0]);
       ___time_to_FILETIME (mtime, &ft[1]);
 
-      h = CreateFile (___CAST(___STRING_TYPE(___TIMES_PATH_CE_SELECT),cpath),
+      h = CreateFile (___CAST(___STRING_TYPE(___PATH_CE_SELECT),cpath),
                       FILE_WRITE_ATTRIBUTES,
                       0,
                       NULL,
@@ -1791,14 +1783,12 @@ ___SCMOBJ chase;)
 #ifndef USE_stat
 #ifndef USE_GetFileAttributesEx
 
-#define ___INFO_PATH_CE_SELECT(latin1,utf8,ucs2,ucs4,wchar,native) native
-
   if ((e = ___SCMOBJ_to_NONNULLSTRING
              (___PSA(___PSTATE)
               path,
               &cpath,
               1,
-              ___CE(___INFO_PATH_CE_SELECT),
+              ___CE(___PATH_CE_SELECT),
               0))
       == ___FIX(___NO_ERR))
     {
@@ -1857,22 +1847,20 @@ ___SCMOBJ chase;)
 
 #ifdef USE_stat
 
-#define ___INFO_PATH_CE_SELECT(latin1,utf8,ucs2,ucs4,wchar,native) native
-
   if ((e = ___SCMOBJ_to_NONNULLSTRING
              (___PSA(___PSTATE)
               path,
               &cpath,
               1,
-              ___CE(___INFO_PATH_CE_SELECT),
+              ___CE(___PATH_CE_SELECT),
               0))
       == ___FIX(___NO_ERR))
     {
       ___struct_stat s;
 
       if (((chase == ___FAL)
-           ? ___lstat (___CAST(___STRING_TYPE(___INFO_PATH_CE_SELECT),cpath), &s)
-           : ___stat (___CAST(___STRING_TYPE(___INFO_PATH_CE_SELECT),cpath), &s))
+           ? ___lstat (___CAST(___STRING_TYPE(___PATH_CE_SELECT),cpath), &s)
+           : ___stat (___CAST(___STRING_TYPE(___PATH_CE_SELECT),cpath), &s))
           < 0)
         {
           e = fnf_or_err_code_from_errno ();
@@ -2032,18 +2020,12 @@ ___SCMOBJ chase;)
 
 #ifdef USE_GetFileAttributesEx
 
-#ifdef _UNICODE
-#define ___INFO_PATH_CE_SELECT(latin1,utf8,ucs2,ucs4,wchar,native) ucs2
-#else
-#define ___INFO_PATH_CE_SELECT(latin1,utf8,ucs2,ucs4,wchar,native) native
-#endif
-
   if ((e = ___SCMOBJ_to_NONNULLSTRING
              (___PSA(___PSTATE)
               path,
               &cpath,
               1,
-              ___CE(___INFO_PATH_CE_SELECT),
+              ___CE(___PATH_CE_SELECT),
               0))
       == ___FIX(___NO_ERR))
     {
@@ -2053,7 +2035,7 @@ ___SCMOBJ chase;)
       ___time ctime;
 
       if (!GetFileAttributesEx
-             (___CAST(___STRING_TYPE(___INFO_PATH_CE_SELECT),cpath),
+             (___CAST(___STRING_TYPE(___PATH_CE_SELECT),cpath),
               GetFileExInfoStandard,
               &fad))
         {

--- a/lib/os_dyn.c
+++ b/lib/os_dyn.c
@@ -14,6 +14,7 @@
 #include "os_base.h"
 #include "os_dyn.h"
 #include "os_shell.h"
+#include "os_files.h"
 
 
 /*---------------------------------------------------------------------------*/

--- a/lib/os_dyn.h
+++ b/lib/os_dyn.h
@@ -13,49 +13,45 @@
 
 #ifdef USE_shl_load
 #define ___DL_DESCR shl_t
-#define ___DL_PATH_CE_SELECT(latin1,utf8,ucs2,ucs4,wchar,native) native
-#define ___DL_MODNAME_CE_SELECT(latin1,utf8,ucs2,ucs4,wchar,native) native
+#define ___DL_PATH_CE_SELECT ___PATH_CE_SELECT
+#define ___DL_MODNAME_CE_SELECT ___PATH_CE_SELECT
 #endif
 
 #ifdef USE_LoadLibrary
 #define ___DL_DESCR HMODULE
-#ifdef _UNICODE
-#define ___DL_PATH_CE_SELECT(latin1,utf8,ucs2,ucs4,wchar,native) ucs2
-#else
-#define ___DL_PATH_CE_SELECT(latin1,utf8,ucs2,ucs4,wchar,native) native
-#endif
+#define ___DL_PATH_CE_SELECT ___PATH_CE_SELECT
 #define ___DL_MODNAME_CE_SELECT(latin1,utf8,ucs2,ucs4,wchar,native) native
 #endif
 
 #ifdef USE_DosLoadModule
 #define ___DL_DESCR HMODULE
-#define ___DL_PATH_CE_SELECT(latin1,utf8,ucs2,ucs4,wchar,native) native
-#define ___DL_MODNAME_CE_SELECT(latin1,utf8,ucs2,ucs4,wchar,native) native
+#define ___DL_PATH_CE_SELECT ___PATH_CE_SELECT
+#define ___DL_MODNAME_CE_SELECT ___PATH_CE_SELECT
 #endif
 
 #ifdef USE_dxe_load
 #define ___DL_DESCR void *
-#define ___DL_PATH_CE_SELECT(latin1,utf8,ucs2,ucs4,wchar,native) native
-#define ___DL_MODNAME_CE_SELECT(latin1,utf8,ucs2,ucs4,wchar,native) native
+#define ___DL_PATH_CE_SELECT ___PATH_CE_SELECT
+#define ___DL_MODNAME_CE_SELECT ___PATH_CE_SELECT
 #endif
 
 #ifdef USE_GetDiskFragment
 #define ___DL_DESCR CFragConnectionID
-#define ___DL_PATH_CE_SELECT(latin1,utf8,ucs2,ucs4,wchar,native) native
-#define ___DL_MODNAME_CE_SELECT(latin1,utf8,ucs2,ucs4,wchar,native) native
+#define ___DL_PATH_CE_SELECT ___PATH_CE_SELECT
+#define ___DL_MODNAME_CE_SELECT ___PATH_CE_SELECT
 #endif
 
 #ifdef USE_dlopen
 #define ___DL_DESCR void *
-#define ___DL_PATH_CE_SELECT(latin1,utf8,ucs2,ucs4,wchar,native) native
-#define ___DL_MODNAME_CE_SELECT(latin1,utf8,ucs2,ucs4,wchar,native) native
+#define ___DL_PATH_CE_SELECT ___PATH_CE_SELECT
+#define ___DL_MODNAME_CE_SELECT ___PATH_CE_SELECT
 #undef ___IMPORTED_ID_PREFIX
 #endif
 
 #ifdef USE_NSLinkModule
 #define ___DL_DESCR NSModule
-#define ___DL_PATH_CE_SELECT(latin1,utf8,ucs2,ucs4,wchar,native) native
-#define ___DL_MODNAME_CE_SELECT(latin1,utf8,ucs2,ucs4,wchar,native) native
+#define ___DL_PATH_CE_SELECT ___PATH_CE_SELECT
+#define ___DL_MODNAME_CE_SELECT ___PATH_CE_SELECT
 #endif
 
 #ifndef ___DL_PATH_CE_SELECT

--- a/lib/os_files.c
+++ b/lib/os_files.c
@@ -1006,18 +1006,16 @@ ___SCMOBJ mode;)
 
 #ifdef USE_mkdir
 
-#define ___CREATE_DIRECTORY_PATH_CE_SELECT(latin1,utf8,ucs2,ucs4,wchar,native) native
-
   if ((e = ___SCMOBJ_to_NONNULLSTRING
              (___PSA(___PSTATE)
               path,
               &cpath,
               1,
-              ___CE(___CREATE_DIRECTORY_PATH_CE_SELECT),
+              ___CE(___PATH_CE_SELECT),
               0))
       == ___FIX(___NO_ERR))
     {
-      if (mkdir (___CAST(___STRING_TYPE(___CREATE_DIRECTORY_PATH_CE_SELECT),cpath), ___INT(mode)) < 0)
+      if (mkdir (___CAST(___STRING_TYPE(___PATH_CE_SELECT),cpath), ___INT(mode)) < 0)
         e = fnf_or_err_code_from_errno ();
       ___release_string (cpath);
     }
@@ -1026,23 +1024,17 @@ ___SCMOBJ mode;)
 
 #ifdef USE_CreateDirectory
 
-#ifdef _UNICODE
-#define ___CREATE_DIRECTORY_PATH_CE_SELECT(latin1,utf8,ucs2,ucs4,wchar,native) ucs2
-#else
-#define ___CREATE_DIRECTORY_PATH_CE_SELECT(latin1,utf8,ucs2,ucs4,wchar,native) native
-#endif
-
   if ((e = ___SCMOBJ_to_NONNULLSTRING
              (___PSA(___PSTATE)
               path,
               &cpath,
               1,
-              ___CE(___CREATE_DIRECTORY_PATH_CE_SELECT),
+              ___CE(___PATH_CE_SELECT),
               0))
       == ___FIX(___NO_ERR))
     {
       if (!CreateDirectory
-            (___CAST(___STRING_TYPE(___CREATE_DIRECTORY_PATH_CE_SELECT),
+            (___CAST(___STRING_TYPE(___PATH_CE_SELECT),
                      cpath),
              NULL))
         e = fnf_or_err_code_from_GetLastError ();
@@ -1074,18 +1066,16 @@ ___SCMOBJ mode;)
 
 #ifdef USE_mkfifo
 
-#define ___CREATE_FIFO_PATH_CE_SELECT(latin1,utf8,ucs2,ucs4,wchar,native) native
-
   if ((e = ___SCMOBJ_to_NONNULLSTRING
              (___PSA(___PSTATE)
               path,
               &cpath,
               1,
-              ___CE(___CREATE_FIFO_PATH_CE_SELECT),
+              ___CE(___PATH_CE_SELECT),
               0))
       == ___FIX(___NO_ERR))
     {
-      if (mkfifo (___CAST(___STRING_TYPE(___CREATE_FIFO_PATH_CE_SELECT),cpath), ___INT(mode)) < 0)
+      if (mkfifo (___CAST(___STRING_TYPE(___PATH_CE_SELECT),cpath), ___INT(mode)) < 0)
         e = fnf_or_err_code_from_errno ();
       ___release_string (cpath);
     }
@@ -1116,14 +1106,12 @@ ___SCMOBJ path2;)
 
 #ifdef USE_link
 
-#define ___CREATE_LINK_PATH_CE_SELECT(latin1,utf8,ucs2,ucs4,wchar,native) native
-
   if ((e = ___SCMOBJ_to_NONNULLSTRING
              (___PSA(___PSTATE)
               path1,
               &cpath1,
               1,
-              ___CE(___CREATE_LINK_PATH_CE_SELECT),
+              ___CE(___PATH_CE_SELECT),
               0))
       == ___FIX(___NO_ERR))
     {
@@ -1132,12 +1120,12 @@ ___SCMOBJ path2;)
                   path2,
                   &cpath2,
                   2,
-                  ___CE(___CREATE_LINK_PATH_CE_SELECT),
+                  ___CE(___PATH_CE_SELECT),
                   0))
           == ___FIX(___NO_ERR))
         {
-          if (link (___CAST(___STRING_TYPE(___CREATE_LINK_PATH_CE_SELECT),cpath1),
-                    ___CAST(___STRING_TYPE(___CREATE_LINK_PATH_CE_SELECT),cpath2))
+          if (link (___CAST(___STRING_TYPE(___PATH_CE_SELECT),cpath1),
+                    ___CAST(___STRING_TYPE(___PATH_CE_SELECT),cpath2))
               < 0)
             e = fnf_or_err_code_from_errno ();
           ___release_string (cpath2);
@@ -1171,14 +1159,12 @@ ___SCMOBJ path2;)
 
 #ifdef USE_symlink
 
-#define ___CREATE_SYMLINK_PATH_CE_SELECT(latin1,utf8,ucs2,ucs4,wchar,native) native
-
   if ((e = ___SCMOBJ_to_NONNULLSTRING
              (___PSA(___PSTATE)
               path1,
               &cpath1,
               1,
-              ___CE(___CREATE_SYMLINK_PATH_CE_SELECT),
+              ___CE(___PATH_CE_SELECT),
               0))
       == ___FIX(___NO_ERR))
     {
@@ -1187,12 +1173,12 @@ ___SCMOBJ path2;)
                   path2,
                   &cpath2,
                   2,
-                  ___CE(___CREATE_SYMLINK_PATH_CE_SELECT),
+                  ___CE(___PATH_CE_SELECT),
                   0))
           == ___FIX(___NO_ERR))
         {
-          if (symlink (___CAST(___STRING_TYPE(___CREATE_SYMLINK_PATH_CE_SELECT),cpath1),
-                       ___CAST(___STRING_TYPE(___CREATE_SYMLINK_PATH_CE_SELECT),cpath2))
+          if (symlink (___CAST(___STRING_TYPE(___PATH_CE_SELECT),cpath1),
+                       ___CAST(___STRING_TYPE(___PATH_CE_SELECT),cpath2))
               < 0)
             e = fnf_or_err_code_from_errno ();
           ___release_string (cpath2);
@@ -1224,18 +1210,16 @@ ___SCMOBJ path;)
 
 #ifdef USE_rmdir
 
-#define ___DELETE_DIRECTORY_PATH_CE_SELECT(latin1,utf8,ucs2,ucs4,wchar,native) native
-
   if ((e = ___SCMOBJ_to_NONNULLSTRING
              (___PSA(___PSTATE)
               path,
               &cpath,
               1,
-              ___CE(___DELETE_DIRECTORY_PATH_CE_SELECT),
+              ___CE(___PATH_CE_SELECT),
               0))
       == ___FIX(___NO_ERR))
     {
-      if (rmdir (___CAST(___STRING_TYPE(___DELETE_DIRECTORY_PATH_CE_SELECT),cpath)) < 0)
+      if (rmdir (___CAST(___STRING_TYPE(___PATH_CE_SELECT),cpath)) < 0)
         e = fnf_or_err_code_from_errno ();
       ___release_string (cpath);
     }
@@ -1244,23 +1228,17 @@ ___SCMOBJ path;)
 
 #ifdef USE_RemoveDirectory
 
-#ifdef _UNICODE
-#define ___DELETE_DIRECTORY_PATH_CE_SELECT(latin1,utf8,ucs2,ucs4,wchar,native) ucs2
-#else
-#define ___DELETE_DIRECTORY_PATH_CE_SELECT(latin1,utf8,ucs2,ucs4,wchar,native) native
-#endif
-
   if ((e = ___SCMOBJ_to_NONNULLSTRING
              (___PSA(___PSTATE)
               path,
               &cpath,
               1,
-              ___CE(___DELETE_DIRECTORY_PATH_CE_SELECT),
+              ___CE(___PATH_CE_SELECT),
               0))
       == ___FIX(___NO_ERR))
     {
       if (!RemoveDirectory
-            (___CAST(___STRING_TYPE(___DELETE_DIRECTORY_PATH_CE_SELECT),
+            (___CAST(___STRING_TYPE(___PATH_CE_SELECT),
                      cpath)))
         e = fnf_or_err_code_from_GetLastError ();
       ___release_string (cpath);
@@ -1290,18 +1268,16 @@ ___SCMOBJ path;)
 
 #ifdef USE_chdir
 
-#define ___SET_CURRENT_DIRECTORY_PATH_CE_SELECT(latin1,utf8,ucs2,ucs4,wchar,native) native
-
   if ((e = ___SCMOBJ_to_NONNULLSTRING
              (___PSA(___PSTATE)
               path,
               &cpath,
               1,
-              ___CE(___SET_CURRENT_DIRECTORY_PATH_CE_SELECT),
+              ___CE(___PATH_CE_SELECT),
               0))
       == ___FIX(___NO_ERR))
     {
-      if (chdir (___CAST(___STRING_TYPE(___SET_CURRENT_DIRECTORY_PATH_CE_SELECT),cpath)) < 0)
+      if (chdir (___CAST(___STRING_TYPE(___PATH_CE_SELECT),cpath)) < 0)
         e = fnf_or_err_code_from_errno ();
       ___release_string (cpath);
     }
@@ -1310,23 +1286,17 @@ ___SCMOBJ path;)
 
 #ifdef USE_SetCurrentDirectory
 
-#ifdef _UNICODE
-#define ___SET_CURRENT_DIRECTORY_PATH_CE_SELECT(latin1,utf8,ucs2,ucs4,wchar,native) ucs2
-#else
-#define ___SET_CURRENT_DIRECTORY_PATH_CE_SELECT(latin1,utf8,ucs2,ucs4,wchar,native) native
-#endif
-
   if ((e = ___SCMOBJ_to_NONNULLSTRING
              (___PSA(___PSTATE)
               path,
               &cpath,
               1,
-              ___CE(___SET_CURRENT_DIRECTORY_PATH_CE_SELECT),
+              ___CE(___PATH_CE_SELECT),
               0))
       == ___FIX(___NO_ERR))
     {
       if (!SetCurrentDirectory
-            (___CAST(___STRING_TYPE(___SET_CURRENT_DIRECTORY_PATH_CE_SELECT),
+            (___CAST(___STRING_TYPE(___PATH_CE_SELECT),
                      cpath)))
         e = fnf_or_err_code_from_GetLastError ();
       ___release_string (cpath);
@@ -1360,14 +1330,12 @@ ___SCMOBJ path2;)
 
 #ifdef USE_rename
 
-#define ___RENAME_FILE_PATH_CE_SELECT(latin1,utf8,ucs2,ucs4,wchar,native) native
-
   if ((e = ___SCMOBJ_to_NONNULLSTRING
              (___PSA(___PSTATE)
               path1,
               &cpath1,
               1,
-              ___CE(___RENAME_FILE_PATH_CE_SELECT),
+              ___CE(___PATH_CE_SELECT),
               0))
       == ___FIX(___NO_ERR))
     {
@@ -1376,12 +1344,12 @@ ___SCMOBJ path2;)
                   path2,
                   &cpath2,
                   2,
-                  ___CE(___RENAME_FILE_PATH_CE_SELECT),
+                  ___CE(___PATH_CE_SELECT),
                   0))
           == ___FIX(___NO_ERR))
         {
-          if (rename (___CAST(___STRING_TYPE(___RENAME_FILE_PATH_CE_SELECT),cpath1),
-                      ___CAST(___STRING_TYPE(___RENAME_FILE_PATH_CE_SELECT),cpath2))
+          if (rename (___CAST(___STRING_TYPE(___PATH_CE_SELECT),cpath1),
+                      ___CAST(___STRING_TYPE(___PATH_CE_SELECT),cpath2))
               < 0)
             e = fnf_or_err_code_from_errno ();
           ___release_string (cpath2);
@@ -1393,18 +1361,12 @@ ___SCMOBJ path2;)
 
 #ifdef USE_MoveFile
 
-#ifdef _UNICODE
-#define ___RENAME_FILE_PATH_CE_SELECT(latin1,utf8,ucs2,ucs4,wchar,native) ucs2
-#else
-#define ___RENAME_FILE_PATH_CE_SELECT(latin1,utf8,ucs2,ucs4,wchar,native) native
-#endif
-
   if ((e = ___SCMOBJ_to_NONNULLSTRING
              (___PSA(___PSTATE)
               path1,
               &cpath1,
               1,
-              ___CE(___RENAME_FILE_PATH_CE_SELECT),
+              ___CE(___PATH_CE_SELECT),
               0))
       == ___FIX(___NO_ERR))
     {
@@ -1413,14 +1375,14 @@ ___SCMOBJ path2;)
                   path2,
                   &cpath2,
                   2,
-                  ___CE(___RENAME_FILE_PATH_CE_SELECT),
+                  ___CE(___PATH_CE_SELECT),
                   0))
           == ___FIX(___NO_ERR))
         {
           if (!MoveFile
-                (___CAST(___STRING_TYPE(___RENAME_FILE_PATH_CE_SELECT),
+                (___CAST(___STRING_TYPE(___PATH_CE_SELECT),
                          cpath1),
-                 ___CAST(___STRING_TYPE(___RENAME_FILE_PATH_CE_SELECT),
+                 ___CAST(___STRING_TYPE(___PATH_CE_SELECT),
                          cpath2)))
             e = fnf_or_err_code_from_GetLastError ();
           ___release_string (cpath2);
@@ -1456,14 +1418,12 @@ ___SCMOBJ path2;)
 
 #ifdef USE_POSIX
 
-#define ___COPY_FILE_PATH_CE_SELECT(latin1,utf8,ucs2,ucs4,wchar,native) native
-
   if ((e = ___SCMOBJ_to_NONNULLSTRING
              (___PSA(___PSTATE)
               path1,
               &cpath1,
               1,
-              ___CE(___COPY_FILE_PATH_CE_SELECT),
+              ___CE(___PATH_CE_SELECT),
               0))
       == ___FIX(___NO_ERR))
     {
@@ -1472,14 +1432,14 @@ ___SCMOBJ path2;)
                   path2,
                   &cpath2,
                   2,
-                  ___CE(___COPY_FILE_PATH_CE_SELECT),
+                  ___CE(___PATH_CE_SELECT),
                   0))
           == ___FIX(___NO_ERR))
         {
           int fd1;
           int fd2;
 
-          if ((fd1 = open (___CAST(___STRING_TYPE(___COPY_FILE_PATH_CE_SELECT),
+          if ((fd1 = open (___CAST(___STRING_TYPE(___PATH_CE_SELECT),
                                    cpath1),
 #ifdef O_BINARY
                            O_BINARY|
@@ -1489,7 +1449,7 @@ ___SCMOBJ path2;)
             e = fnf_or_err_code_from_errno ();
           else
             {
-              if ((fd2 = open (___CAST(___STRING_TYPE(___COPY_FILE_PATH_CE_SELECT),
+              if ((fd2 = open (___CAST(___STRING_TYPE(___PATH_CE_SELECT),
                                        cpath2),
 #ifdef O_BINARY
                                O_BINARY|
@@ -1530,7 +1490,7 @@ ___SCMOBJ path2;)
               if (close (fd1) < 0 && e != ___FIX(___NO_ERR))
                 {
                   e = err_code_from_errno ();
-                  unlink (___CAST(___STRING_TYPE(___COPY_FILE_PATH_CE_SELECT),
+                  unlink (___CAST(___STRING_TYPE(___PATH_CE_SELECT),
                                   cpath2));
                 }
             }
@@ -1543,18 +1503,12 @@ ___SCMOBJ path2;)
 
 #ifdef USE_CopyFile
 
-#ifdef _UNICODE
-#define ___COPY_FILE_PATH_CE_SELECT(latin1,utf8,ucs2,ucs4,wchar,native) ucs2
-#else
-#define ___COPY_FILE_PATH_CE_SELECT(latin1,utf8,ucs2,ucs4,wchar,native) native
-#endif
-
   if ((e = ___SCMOBJ_to_NONNULLSTRING
              (___PSA(___PSTATE)
               path1,
               &cpath1,
               1,
-              ___CE(___COPY_FILE_PATH_CE_SELECT),
+              ___CE(___PATH_CE_SELECT),
               0))
       == ___FIX(___NO_ERR))
     {
@@ -1563,14 +1517,14 @@ ___SCMOBJ path2;)
                   path2,
                   &cpath2,
                   2,
-                  ___CE(___COPY_FILE_PATH_CE_SELECT),
+                  ___CE(___PATH_CE_SELECT),
                   0))
           == ___FIX(___NO_ERR))
         {
           if (!CopyFile
-                (___CAST(___STRING_TYPE(___COPY_FILE_PATH_CE_SELECT),
+                (___CAST(___STRING_TYPE(___PATH_CE_SELECT),
                          cpath1),
-                 ___CAST(___STRING_TYPE(___COPY_FILE_PATH_CE_SELECT),
+                 ___CAST(___STRING_TYPE(___PATH_CE_SELECT),
                          cpath2),
                  1))
             e = fnf_or_err_code_from_GetLastError ();
@@ -1603,18 +1557,16 @@ ___SCMOBJ path;)
 
 #ifdef USE_unlink
 
-#define ___DELETE_FILE_PATH_CE_SELECT(latin1,utf8,ucs2,ucs4,wchar,native) native
-
   if ((e = ___SCMOBJ_to_NONNULLSTRING
              (___PSA(___PSTATE)
               path,
               &cpath,
               1,
-              ___CE(___DELETE_FILE_PATH_CE_SELECT),
+              ___CE(___PATH_CE_SELECT),
               0))
       == ___FIX(___NO_ERR))
     {
-      if (unlink (___CAST(___STRING_TYPE(___DELETE_FILE_PATH_CE_SELECT),cpath))
+      if (unlink (___CAST(___STRING_TYPE(___PATH_CE_SELECT),cpath))
           < 0)
         e = fnf_or_err_code_from_errno ();
       ___release_string (cpath);
@@ -1624,23 +1576,17 @@ ___SCMOBJ path;)
 
 #ifdef USE_DeleteFile
 
-#ifdef _UNICODE
-#define ___DELETE_FILE_PATH_CE_SELECT(latin1,utf8,ucs2,ucs4,wchar,native) ucs2
-#else
-#define ___DELETE_FILE_PATH_CE_SELECT(latin1,utf8,ucs2,ucs4,wchar,native) native
-#endif
-
   if ((e = ___SCMOBJ_to_NONNULLSTRING
              (___PSA(___PSTATE)
               path,
               &cpath,
               1,
-              ___CE(___DELETE_FILE_PATH_CE_SELECT),
+              ___CE(___PATH_CE_SELECT),
               0))
       == ___FIX(___NO_ERR))
     {
       if (!DeleteFile
-            (___CAST(___STRING_TYPE(___DELETE_FILE_PATH_CE_SELECT),
+            (___CAST(___STRING_TYPE(___PATH_CE_SELECT),
                      cpath)))
         e = fnf_or_err_code_from_GetLastError ();
       ___release_string (cpath);

--- a/lib/os_files.h
+++ b/lib/os_files.h
@@ -40,7 +40,7 @@ extern ___files_module ___files_mod;
 #endif
 
 #ifndef ___PATH_CE_SELECT
-#define ___PATH_CE_SELECT(latin1,utf8,ucs2,ucs4,wchar,native) native
+#define ___PATH_CE_SELECT(latin1,utf8,ucs2,ucs4,wchar,native) utf8
 #endif
 
 

--- a/lib/os_io.c
+++ b/lib/os_io.c
@@ -4871,15 +4871,11 @@ ___HIDDEN ___device_directory_vtbl ___device_directory_table =
 
 
 #ifdef USE_opendir
-#define ___DIR_OPEN_PATH_CE_SELECT(latin1,utf8,ucs2,ucs4,wchar,native) native
+#define ___DIR_OPEN_PATH_CE_SELECT
 #endif
 
 #ifdef USE_FindFirstFile
-#ifdef _UNICODE
-#define ___DIR_OPEN_PATH_CE_SELECT(latin1,utf8,ucs2,ucs4,wchar,native) ucs2
-#else
-#define ___DIR_OPEN_PATH_CE_SELECT(latin1,utf8,ucs2,ucs4,wchar,native) native
-#endif
+#define ___DIR_OPEN_PATH_CE_SELECT
 #endif
 
 
@@ -4888,7 +4884,7 @@ ___HIDDEN ___device_directory_vtbl ___device_directory_table =
 ___SCMOBJ ___device_directory_setup
    ___P((___device_directory **dev,
          ___device_group *dgroup,
-         ___STRING_TYPE(___DIR_OPEN_PATH_CE_SELECT) path,
+         ___STRING_TYPE(___PATH_CE_SELECT) path,
          int ignore_hidden),
         (dev,
          dgroup,
@@ -4896,7 +4892,7 @@ ___SCMOBJ ___device_directory_setup
          ignore_hidden)
 ___device_directory **dev;
 ___device_group *dgroup;
-___STRING_TYPE(___DIR_OPEN_PATH_CE_SELECT) path;
+___STRING_TYPE(___PATH_CE_SELECT) path;
 int ignore_hidden;)
 {
   ___device_directory *d;
@@ -4932,7 +4928,7 @@ int ignore_hidden;)
 #ifdef USE_FindFirstFile
 
   {
-    ___CHAR_TYPE(___DIR_OPEN_PATH_CE_SELECT) dir[___PATH_MAX_LENGTH+2+1];
+    ___CHAR_TYPE(___PATH_CE_SELECT) dir[___PATH_MAX_LENGTH+2+1];
     int i = 0;
 
     while (path[i] != '\0' && i < ___PATH_MAX_LENGTH)
@@ -4973,11 +4969,11 @@ int ignore_hidden;)
 
 ___SCMOBJ ___device_directory_read
    ___P((___device_directory *dev,
-         ___STRING_TYPE(___DIR_OPEN_PATH_CE_SELECT) *name),
+         ___STRING_TYPE(___PATH_CE_SELECT) *name),
         (dev,
          name)
 ___device_directory *dev;
-___STRING_TYPE(___DIR_OPEN_PATH_CE_SELECT) *name;)
+___STRING_TYPE(___PATH_CE_SELECT) *name;)
 {
   ___SCMOBJ e;
 
@@ -4986,7 +4982,7 @@ ___STRING_TYPE(___DIR_OPEN_PATH_CE_SELECT) *name;)
 
   for (;;)
     {
-      ___STRING_TYPE(___DIR_OPEN_PATH_CE_SELECT) temp;
+      ___STRING_TYPE(___PATH_CE_SELECT) temp;
 
 #ifdef USE_opendir
 
@@ -7492,22 +7488,12 @@ ___SCMOBJ dev;)
 
 /*---------------------------------------------------------------------------*/
 
-#ifndef USE_POSIX
-#ifndef USE_WIN32
-#define ___STREAM_OPEN_PATH_CE_SELECT(latin1,utf8,ucs2,ucs4,wchar,native) native
-#endif
-#endif
-
 #ifdef USE_POSIX
-#define ___STREAM_OPEN_PATH_CE_SELECT(latin1,utf8,ucs2,ucs4,wchar,native) native
+#define ___STREAM_OPEN_PATH_CE_SELECT
 #endif
 
 #ifdef USE_WIN32
-#ifdef _UNICODE
-#define ___STREAM_OPEN_PATH_CE_SELECT(latin1,utf8,ucs2,ucs4,wchar,native) ucs2
-#else
-#define ___STREAM_OPEN_PATH_CE_SELECT(latin1,utf8,ucs2,ucs4,wchar,native) native
-#endif
+#define ___STREAM_OPEN_PATH_CE_SELECT
 #endif
 
 
@@ -7516,7 +7502,7 @@ ___SCMOBJ dev;)
 ___SCMOBJ ___device_stream_setup_from_path
    ___P((___device_stream **dev,
          ___device_group *dgroup,
-         ___STRING_TYPE(___STREAM_OPEN_PATH_CE_SELECT) path,
+         ___STRING_TYPE(___PATH_CE_SELECT) path,
          int flags,
          int mode),
         (dev,
@@ -7526,7 +7512,7 @@ ___SCMOBJ ___device_stream_setup_from_path
          mode)
 ___device_stream **dev;
 ___device_group *dgroup;
-___STRING_TYPE(___STREAM_OPEN_PATH_CE_SELECT) path;
+___STRING_TYPE(___PATH_CE_SELECT) path;
 int flags;
 int mode;)
 {
@@ -8554,14 +8540,14 @@ ___SCMOBJ ignore_hidden;)
               path,
               &cpath,
               1,
-              ___CE(___DIR_OPEN_PATH_CE_SELECT),
+              ___CE(___PATH_CE_SELECT),
               0))
       != ___FIX(___NO_ERR))
     result = e;
   else
     {
-      ___STRING_TYPE(___DIR_OPEN_PATH_CE_SELECT) p =
-        ___CAST(___STRING_TYPE(___DIR_OPEN_PATH_CE_SELECT),cpath);
+      ___STRING_TYPE(___PATH_CE_SELECT) p =
+        ___CAST(___STRING_TYPE(___PATH_CE_SELECT),cpath);
 
       if ((e = ___device_directory_setup
                  (&dev,
@@ -8611,7 +8597,7 @@ ___SCMOBJ dev;)
   ___device_directory *d =
     ___CAST(___device_directory*,___FIELD(dev,___FOREIGN_PTR));
   ___SCMOBJ e;
-  ___STRING_TYPE(___DIR_OPEN_PATH_CE_SELECT) name;
+  ___STRING_TYPE(___PATH_CE_SELECT) name;
   ___SCMOBJ result;
 
   if ((e = ___device_directory_read (d, &name)) != ___FIX(___NO_ERR))
@@ -8620,7 +8606,7 @@ ___SCMOBJ dev;)
   if (name == NULL)
     return ___EOF;
 
-  if ((e = ___STRING_to_SCMOBJ (___PSTATE, name, &result, ___RETURN_POS, ___CE(___DIR_OPEN_PATH_CE_SELECT) ))
+  if ((e = ___STRING_to_SCMOBJ (___PSTATE, name, &result, ___RETURN_POS, ___CE(___PATH_CE_SELECT) ))
       != ___FIX(___NO_ERR))
     return e;
 


### PR DESCRIPTION
All file functions use the same macro for determining the type for a file path. The type on non-Windows systems is now "utf8" instead of "native". Function "directory-files" now works fine on OS X with the path "äöü".

There are also some macros for process names that might be considered as well (e.g. ___STREAM_OPEN_PROCESS_CE_SELECT). These names are probably also file names.