### PR TITLE
Improve AArch64 handling.

### DIFF
--- a/include/gambit.h.in
+++ b/include/gambit.h.in
@@ -328,17 +328,6 @@
 #ifdef __arm__
 #define ___CPU_arm
 #else
-#ifdef arm64
-#define ___CPU_arm
-#else
-#ifdef __arm64
-#define ___CPU_arm
-#else
-#ifdef __arm64__
-#define ___CPU_arm
-#endif
-#endif
-#endif
 #endif
 #endif
 #endif
@@ -359,6 +348,14 @@
 #endif
 #endif
 
+#endif
+
+#ifdef __aarch64__
+#define ___CPU_aarch64
+#else
+#ifdef __arm64__
+#define ___CPU_aarch64
+#endif
 #endif
 
 /*
@@ -433,6 +430,11 @@
 #endif
 
 #ifdef EMSCRIPTEN
+#define ___LITTLE_ENDIAN
+#endif
+
+/* AArch64 can be little or big endian*/
+#ifdef __AARCH64EL__
 #define ___LITTLE_ENDIAN
 #endif
 


### PR DESCRIPTION
AArch64 (64-bit ARMv8) is different architecture that ARM so let's treat
it that way.

It can also be big or little endian so check for little endian one is
added.