### PR TITLE
Ffi

### DIFF
--- a/gsc/_t-univ.scm
+++ b/gsc/_t-univ.scm
@@ -6538,6 +6538,351 @@ EOF
     ((apply5)
      (apply-procedure 5))
 
+    ((host_function2scm)
+     (rts-method
+      'host_function2scm
+      '(public)
+      'object
+      (list (univ-field 'obj 'object))
+      "\n"
+      '()
+      (lambda (ctx)
+       (let ((obj (^local-var "obj"))
+             (host_function_closure (^local-var "host_function_closure")))
+        (^ 
+            (^prim-function-declaration
+            "host_function_closure"
+            'object
+            '() 
+            "\n"
+            '()
+            (^return-call-prim 
+              (^rts-method (univ-use-rtlib ctx 'scm2host_call))
+              obj))
+           (^return host_function_closure))))))
+
+    ((host2scm)
+     (rts-method
+      'host2scm
+      '(public)
+      'scmobj
+      (list (univ-field 'obj 'object))
+      "\n"
+      '()
+      (lambda (ctx)
+        (let ((obj (^local-var 'obj))
+              (alist (^local-var 'alist))
+              (key (^local-var 'key)))
+          (^
+           (if (eq? (target-name (ctx-target ctx)) 'js)
+               (^if (^void? obj)
+                    (^return (^void-obj)))
+               (^))
+
+           (^if (^null? obj)
+                (if (and (eq? (univ-void-representation ctx) 'host)
+                         ; Javascript has a native "void" in "undefined".
+                         (not (eq? (target-name (ctx-target ctx)) 'js)))
+                    (^return (^void-obj))
+                    (^return (^null-obj))))
+
+           (^if (^bool? obj)
+                (^return (^boolean-box obj)))
+
+           (case (target-name (ctx-target ctx))
+            ((js)
+             (^if (^typeof "number" obj)
+                  (^if (^and (^eq? (^parens (^bitior obj 0)) obj)
+                             (^and (^>= obj -536870912)
+                                   (^<= obj 536870911)))
+                       (^return (^fixnum-box obj))
+                       (^return (^flonum-box obj)))))
+            (else
+             (^ (^if (^and (^int? obj)
+                           (^and (^>= obj -536870912)
+                                 (^<= obj 536870911)))
+                     (^return (^fixnum-box obj)))
+                (^if (^float? obj)
+                     (^return (^flonum-box obj))))))
+
+           (^if (^float? obj)
+                (^return (^flonum-box obj)))
+
+           (case (target-name (ctx-target ctx))
+            ((php)
+             (^ ))
+            (else
+             (^if (^function? obj)
+                  (^return-call-prim 
+                   (^rts-method (univ-use-rtlib ctx 'host_function2scm))
+                   obj))))
+
+           (^if (^str? obj)
+                (^return (^string-box (^str-to-codes obj))))
+
+           ; TODO: generalise for python, java, ruby and php
+           (^if (^typeof "object" obj)
+                (^if (^instanceof "Array" obj)
+                     (^return (^map (^rts-method (univ-use-rtlib ctx 'js2scm)) obj))
+                     (^
+                       (^var-declaration '() alist (^null-obj))
+                       "for (var " key " in " obj ") {\n"
+                           (^assign alist (^cons (^cons (^call-prim
+                                                        (^rts-method (univ-use-rtlib ctx 'js2scm))
+                                                        key)
+                                                       (^call-prim
+                                                        (^rts-method (univ-use-rtlib ctx 'js2scm))
+                                                        (^array-index obj key)))
+                                                alist))
+                       "}\n"                       
+                       (^return alist))))
+            ;; Handle scheme objects represented as classes.
+#;
+           (case (univ-void-representation ctx)
+            ((host) (^))
+            ((class)
+             (^if (^void? obj)
+                  (^return obj))))
+#;
+           (case (univ-null-representation ctx)
+            ((host) (^))
+            ((class)
+             (^if (^null? obj)
+               (^return obj))))
+#;
+           (case (univ-boolean-representation ctx)
+            ((host) (^))
+            ((class)
+             (^if (^boolean? obj)
+                  (^return obj))))
+#;
+           (case (univ-string-representation ctx)
+            ((host) (^))
+            ((class)
+             (^if (^string? obj)
+                  (^return obj))))
+#;
+           (case (univ-fixnum-representation ctx)
+            ((host) (^))
+            ((class)
+             (^if (^fixnum? obj)
+                  (^return obj))))
+#;
+           (case (univ-flonum-representation ctx)
+            ((host) (^))
+            ((class)
+             (^if (^flonum? obj)
+                  (^return obj))))
+#;
+           (case (univ-procedure-representation ctx)
+            ((host) (^))
+            ((class)
+             (^if (^procedure? obj)
+               (^return obj))))
+
+           (univ-throw ctx "\"Gambit_host2scm error\""))))))
+
+    ((host2scm_call)
+     (rts-method
+      'host2scm_call
+      '(public)
+      'object
+      (list (univ-field 'proc 'scmobj)
+            (univ-field 'args 'scmobj))
+      "\n"
+      '()
+      (lambda (ctx)
+       (let ((args (^local-var "args"))
+             (i (^local-var "i"))
+             (proc (^local-var "proc")))
+         (^ 
+            (^assign (gvm-state-sp-use ctx 'wr) -1)
+            (^push (^null-obj))
+            (^assign (^getnargs) (^array-length args))
+            (^assign i 0)
+            (^while (^< i (^getnargs))
+              (^ (^push
+                   (^call-prim (^rts-method (univ-use-rtlib ctx 'host2scm))
+                               (^array-index args i)))
+                 (^inc-by i 1)))
+            (univ-pop-args-to-regs ctx 0)
+            (^assign (^getreg 0) (^rts-method (univ-use-rtlib ctx 'underflow)))
+            (^expr-statement
+              (^call-prim (^rts-method (univ-use-rtlib ctx 'trampoline))
+                          proc))
+            (^return-call-prim (^rts-method(univ-use-rtlib ctx 'scm2host))
+                               (^getreg 1)))))))
+
+    ((scm_procedure2host)
+     (rts-method
+      'scm_procedure2host
+      '(public)
+      'object
+      (list (univ-field 'obj 'scmobj))
+      "\n"
+      '()
+      (lambda (ctx)
+       (let ((obj (^local-var "obj"))
+             (arguments  (^local-var "arguments"))
+             (scm_procedure (^local-var "scm_procedure")))
+         (^
+          (^prim-function-declaration
+           "scm_procedure"                              ;name
+           'object
+           (case (target-name (ctx-target ctx))         ;argument
+            ((js php) '())
+            ((python ruby) `(("*arguments" . #f))))
+           "\n"                                         ;header
+           (^)                                          ;attribs
+           (^ (case (target-name (ctx-target ctx))      ;body
+               ((php)
+                (^var-declaration '() arguments (^call-prim "func_get_args")))
+               (else ""))
+              (^return 
+               (^call-prim (^rts-method (univ-use-rtlib ctx 'host2scm_call))
+                           obj
+                           arguments))))
+            (^return scm_procedure))))))
+
+    ((scm2host)
+     (rts-method
+      'scm2host
+      '(public)
+      'object
+      (list (univ-field 'obj 'scmobj))
+      "\n"
+      '()
+      (lambda (ctx)
+       (let ((obj (^local-var "obj")))
+         (^
+          (^if (^void? obj)
+            (case (univ-void-representation ctx)
+             ((host) (^return obj))
+             ((class)
+              (^return (case (target-name (ctx-target ctx))
+                        ((js) (^void))
+                        (else (^null)))))))
+
+          (^if (^null? obj)
+               (case (univ-null-representation ctx)
+                ((host) (^return obj))
+                ((class)
+                 (^return (case (target-name (ctx-target ctx))
+                           ((js) (^null))
+                           (else obj)))))) 
+ 
+          (^if (^boolean? obj)
+               (^return (^boolean-unbox obj)))
+
+          (^if (^fixnum? obj)
+               (^return (^fixnum-unbox obj)))
+
+          (^if (^flonum? obj)
+               (^return (^flonum-unbox obj)))
+
+          (^if (^string? obj)
+               (case (univ-string-representation ctx)
+                ((class)
+                 (^return (^tostr obj)))
+                ((host)
+                 (^return obj))))
+
+          ; TODO: generalise for python, ruby, php and java
+          (^if (^instanceof "Array" obj)
+               (^return (^map (^rts-method (univ-use-rtlib ctx 'scm2host)) obj)))
+          
+          ; TODO: generalise for python, ruby, php and java
+          (^if (^pair? obj)
+               (let ((jsobj (^local-var "jsobj"))
+                     (i (^local-var "i"))
+                     (elem (^local-var "elem")))
+
+                 (^
+                   (^var-declaration '() jsobj "{}")
+                   (^var-declaration 'int i (^int 0))
+                   (^while (^pair? obj)
+                     (^ (^var-declaration '() elem (^getcar obj))
+                        (^if (^pair? elem)
+                             (^assign
+                               (^array-index
+                                obj
+                                (^call-prim
+                                 (^rts-method (univ-use-rtlib ctx 'scm2host))
+                                 (^getcar elem)))
+                               (^call-prim
+                                (^rts-method (univ-use-rtlib ctx 'scm2host))
+                                (^getcdr elem)))
+                             (^assign
+                               (^array-index obj i)
+                               (^call-prim
+                                (^rts-method (univ-use-rtlib ctx 'scm2host))
+                                elem)))
+                        (^inc-by i 1)
+                        (^assign obj (^getcdr obj))))
+                   (^return jsobj))))
+
+           (^if (^structure? obj)
+                (univ-throw ctx "\"Gambit.scm2js error (cannot convert Structure)\""))
+
+          (case (target-name (ctx-target ctx))
+           ((php) (^))
+           (else
+            (^if (^procedure? obj)
+                 (^return-call-prim
+                   (^rts-method (univ-use-rtlib ctx 'scm_procedure2host))
+                   obj))))
+
+          (univ-throw ctx "\"Gambit_scm2host error\""))))))
+
+    ((scm2host_call)
+     (rts-method
+      'scm2host_call
+      '(public)
+      'jumpable
+      (list (univ-field 'fn 'object))
+      "\n"
+      '()
+      (lambda (ctx)
+       (let ((args (^local-var "args"))
+             (ra (^local-var "ra"))
+             (frame (^local-var "frame"))
+             (tmp (^local-var "tmp"))
+             (fn (^local-var "fn")))
+         (^
+          (univ-push-args ctx)
+          (^var-declaration '()
+                            args
+                            (^subarray
+                               (gvm-state-stack-use ctx 'rd)
+                               (^- (^+ (gvm-state-sp-use ctx 'rd) 1)
+                                       (^getnargs))
+                               (^getnargs)))
+          (^inc-by (gvm-state-sp-use ctx 'rdwr) (^- (^getnargs)))
+          (^var-declaration '()
+                            ra
+                            (^call-prim
+                             (^rts-method (univ-use-rtlib ctx 'heapify_cont))
+                             (^getreg 0)))
+          (^var-declaration '()
+                            frame
+                            (^array-index (gvm-state-stack-use ctx 'rd) 0))
+          (^var-declaration '()
+                            tmp
+                            (^map (^rts-method (univ-use-rtlib ctx  
+                                                               'scm2host))
+                                  args))
+          (^assign tmp (^call-with-arg-array fn tmp))
+          (^assign (^getreg 1)
+                   (^call-prim (^rts-method (univ-use-rtlib ctx 'host2scm))
+                               tmp))
+          (^assign (gvm-state-sp-use ctx 'wr) -1)
+          (^inc-by (gvm-state-sp-use ctx 'rdwr)
+                   1
+                   (lambda (x)
+                     (^assign (^array-index (gvm-state-stack-use ctx 'wr) x)
+                              frame)))
+          (^return ra))))))
+
     ((js2scm)
      (rts-method
       'js2scm
@@ -6725,6 +7070,12 @@ EOF
      ((ffi)
       (case (target-name (ctx-target ctx))
        ((js)
+        (univ-use-rtlib ctx 'host_function2scm)
+        (univ-use-rtlib ctx 'host2scm)
+        (univ-use-rtlib ctx 'host2scm_call)
+        (univ-use-rtlib ctx 'scm2host)
+        (univ-use-rtlib ctx 'scm_procedure2host)
+        (univ-use-rtlib ctx 'scm2host_call)
         (univ-use-rtlib ctx 'js2scm)
         (univ-use-rtlib ctx 'scm2js)
         (univ-use-rtlib ctx 'js2scm_call)

--- a/gsc/_t-univ.scm
+++ b/gsc/_t-univ.scm
@@ -897,6 +897,14 @@
 (define-macro (^return expr)
   `(univ-emit-return ctx ,expr))
 
+
+
+(define-macro (^map fn array)
+  `(univ-emit-map ctx ,fn ,array))
+
+(define-macro (^call-with-arg-array fn vals)
+  `(univ-emit-call-with-arg-array ctx ,fn ,vals))
+
 ;;
 ;; Host vs Scheme type correspondance
 ;;
@@ -1454,6 +1462,44 @@
   (popcount arg
             (^assign arg (^bitand arg (^int univ-fixnum-max*2+1)))
             1))
+
+(define (univ-emit-map ctx fn array)
+  (case (target-name (ctx-target ctx))
+
+    ((js)
+     (^ array ".map( " fn " )"))
+
+    ((php)
+     (^ "array_map( '" fn "', " array ")"))
+
+    ((python)
+     (^ "map( "fn ", " array " )"))
+
+    ((ruby)
+     (^ array ".map { |x| " fn "(x) } " ))
+
+    (else
+     (compiler-internal-error
+      "univ-emit-map, unknown target"))))
+ 
+(define (univ-emit-call-with-arg-array ctx fn array)
+  (case (target-name (ctx-target ctx))
+
+    ((js)
+     (^ fn ".apply( null, " array " )"))
+
+    ((php)
+     (^ "call_user_func_array( " fn ", " array " )"))
+
+    ((python)
+     (^ fn "( *" array " )"))
+
+    ((ruby)
+     (^ fn ".( *" array " )"))
+
+    (else
+     (compiler-internal-error
+      "univ-emit-call-with-arg-array, unknown target"))))
 
 (define (univ-emit-var-declaration ctx type name #!optional (init #f))
   (case (target-name (ctx-target ctx))

--- a/gsc/_t-univ.scm
+++ b/gsc/_t-univ.scm
@@ -7566,8 +7566,8 @@ gambit_Pair.prototype.toString = function () {
    (univ-jumpable-declaration-defs
     ctx
     global?
-    proc-type
     root-name
+    proc-type
     params
     attribs
     body)))
@@ -10727,7 +10727,10 @@ tanh
     ((js php)
      (^ "throw " expr ";\n"))
 
-    ((python ruby)
+    ((python)
+     (^ "raise Exception(" expr ")\n"))
+
+    ((ruby)
      (^ "raise " expr "\n"))
 
     (else

--- a/gsc/tests/40-univ/bijectiveproc.scm
+++ b/gsc/tests/40-univ/bijectiveproc.scm
@@ -1,0 +1,70 @@
+(declare (extended-bindings) (not safe))
+
+(##define-macro (case-target . clauses)
+  (let ((target (if (and (pair? ##compilation-options)
+                          (pair? (car ##compilation-options)))
+                    (let ((t (assq 'target ##compilation-options)))
+                      (if t (cadr t) 'c))
+                    'c)))
+    (let loop ((clauses clauses))
+      (if (pair? clauses)
+          (let* ((clause (car clauses))
+                  (cases (car clause)))
+            (if (or (eq? cases 'else)
+                    (memq target cases))
+                `(begin ,@(cdr clause))
+                (loop (cdr clauses))))
+          `(begin)))))
+
+(##define-macro (define-target name . clauses)
+  `(define ,name (case-target ,@clauses)))
+
+(define-target (bijective-fn x)
+ ((js)
+  (let ((tmp (##inline-host-expression "((typeof Gambit_RTS !== 'undefined') ? Gambit_RTS.scm_procedure2host : gambit_scm_procedure2host)(@1@)" x)))
+    (let ((res (##inline-host-expression "((typeof Gambit_RTS !== 'undefined') ? Gambit_RTS.host_function2scm : gambit_host_function2scm)(@1@)" tmp)))
+      res)))
+ ((php ruby python)
+  (let ((tmp (##inline-host-expression "gambit_scm_procedure2host(@1@)" x)))
+    (let ((res (##inline-host-expression "gambit_host_function2scm(@1@)" tmp)))
+      res)))
+; ((module)
+;  (let ((tmp (##inline-host-expression "Gambit_RTS.scm_procedure2host(@1@)" x)))
+;    (let ((res (##inline-host-expression "Gambit_RTS.host_function2scm(@1@)" tmp)))
+;      res)))
+ (else (bijective x)))
+
+(define-target (bijective x)
+ ((js)
+  (let ((tmp (##inline-host-expression "((typeof Gambit_RTS !== 'undefined') ? Gambit_RTS.scm2host : gambit_scm2host)(@1@)" x)))
+    (let ((res (##inline-host-expression "((typeof Gambit_RTS !== 'undefined') ? Gambit_RTS.host2scm : gambit_host2scm)(@1@)" tmp)))
+      res)))
+ ((php ruby python)
+  (let ((tmp (##inline-host-expression "gambit_scm2host(@1@)" x)))
+    (let ((res (##inline-host-expression "gambit_host2scm(@1@)" tmp)))
+      res)))
+;   ((module)
+;    (let ((tmp (##inline-host-expression "Gambit_RTS.host2scm(@1@)" x)))
+;     (let ((res (##inline-host-expression "Gambit_RTS.host2scm(@1@)" tmp)))
+;       res)))
+
+ (else x))
+
+;;----------------------------------------------------------------------------
+
+(define (id x) x)
+
+(define (rest a b . c) (##car c))
+  
+(println ((bijective-fn id) "id"))
+(println ((bijective-fn rest) "a" "b" "c" "d" "e"))
+
+(case-target
+ ((php)
+  (begin
+   (println ((bijective-fn id) "id"))
+   (println ((bijective-fn rest) "a" "b" "c" "d" "e"))))
+ (else
+  (begin
+   (println ((bijective id) "id")))
+   (println ((bijective rest) "a" "b" "c" "d" "e"))))

--- a/gsc/tests/40-univ/bijectivetype.scm
+++ b/gsc/tests/40-univ/bijectivetype.scm
@@ -1,0 +1,86 @@
+(declare (extended-bindings) (not safe))
+
+(##define-macro (case-target . clauses)
+  (let ((target (if (and (pair? ##compilation-options)
+                          (pair? (car ##compilation-options)))
+                    (let ((t (assq 'target ##compilation-options)))
+                      (if t (cadr t) 'c))
+                    'c)))
+    (let loop ((clauses clauses))
+      (if (pair? clauses)
+          (let* ((clause (car clauses))
+                  (cases (car clause)))
+            (if (or (eq? cases 'else)
+                    (memq target cases))
+                `(begin ,@(cdr clause))
+                (loop (cdr clauses))))
+          `(begin)))))
+
+(##define-macro (define-target name . clauses)
+  `(define ,name (case-target ,@clauses)))
+
+(define-target (bijective-fn x)
+ ((js)
+  (let ((tmp (##inline-host-expression "((typeof Gambit_RTS !== 'undefined') ? Gambit_RTS.scm_procedure2host : gambit_scm_procedure2host)(@1@)" x)))
+    (let ((res (##inline-host-expression "((typeof Gambit_RTS !== 'undefined') ? Gambit_RTS.host_function2scm : gambit_host_function2scm)(@1@)" tmp)))
+      res)))
+ ((php ruby python)
+  (let ((tmp (##inline-host-expression "gambit_scm_procedure2host(@1@)" x)))
+    (let ((res (##inline-host-expression "gambit_host_function2scm(@1@)" tmp)))
+      res)))
+; ((module)
+;  (let ((tmp (##inline-host-expression "Gambit_RTS.scm_procedure2host(@1@)" x)))
+;    (let ((res (##inline-host-expression "Gambit_RTS.host_function2scm(@1@)" tmp)))
+;      res)))
+
+ (else (bijective x)))
+
+(define-target (bijective x)
+ ((js)
+  (let ((tmp (##inline-host-expression "((typeof Gambit_RTS !== 'undefined') ? Gambit_RTS.scm2host : gambit_scm2host)(@1@)" x)))
+    (let ((res (##inline-host-expression "((typeof Gambit_RTS !== 'undefined') ? Gambit_RTS.host2scm : gambit_host2scm)(@1@)" tmp)))
+      res)))
+ ((php ruby python)
+  (let ((tmp (##inline-host-expression "gambit_scm2host(@1@)" x)))
+    (let ((res (##inline-host-expression "gambit_host2scm(@1@)" tmp)))
+      res)))
+; ((module)
+;  (let ((tmp (##inline-host-expression "Gambit_RTS.scm2host(@1@)" x)))
+;    (let ((res (##inline-host-expression "Gambit_RTS.host2scm(@1@)" tmp)))
+;       res)))
+
+ (else x))
+
+;;----------------------------------------------------------------------------
+
+;;
+(##define-macro (test type? x)
+  `(println (if (,type? ,x) "type check: OK" "type check: ERR")))
+
+(define (id x) x)
+
+;; null
+(test ##null? (bijective '()))
+
+;; void
+;(test ##void? (bijective #!void))
+
+;; boolean
+(test ##boolean? (bijective #t))
+(test ##boolean? (bijective #f))
+
+;; integer
+(test ##fixnum? (bijective 0))
+(test ##fixnum? (bijective 1))
+(test ##fixnum? (bijective -1))
+
+;; float
+(test ##flonum? (bijective 1.5))
+(test ##flonum? (bijective -1.5))
+
+;; string
+(test ##string? (bijective ""))
+(test ##string? (bijective "string"))
+
+;; procedure
+(test ##procedure? (bijective-fn id))

--- a/gsc/tests/40-univ/bijectiveval.scm
+++ b/gsc/tests/40-univ/bijectiveval.scm
@@ -1,0 +1,63 @@
+(declare (extended-bindings) (not safe))
+
+(##define-macro (case-target . clauses)
+  (let ((target (if (and (pair? ##compilation-options)
+                          (pair? (car ##compilation-options)))
+                    (let ((t (assq 'target ##compilation-options)))
+                      (if t (cadr t) 'c))
+                    'c)))
+    (let loop ((clauses clauses))
+      (if (pair? clauses)
+          (let* ((clause (car clauses))
+                  (cases (car clause)))
+            (if (or (eq? cases 'else)
+                    (memq target cases))
+                `(begin ,@(cdr clause))
+                (loop (cdr clauses))))
+          `(begin)))))
+
+(##define-macro (define-target name . clauses)
+  `(define ,name (case-target ,@clauses)))
+
+(define-target (bijective x)
+ ((js)
+  (let ((tmp (##inline-host-expression "((typeof Gambit_RTS !== 'undefined') ? Gambit_RTS.scm2host : gambit_scm2host)(@1@)" x)))
+    (let ((res (##inline-host-expression "((typeof Gambit_RTS !== 'undefined') ? Gambit_RTS.host2scm : gambit_host2scm)(@1@)" tmp)))
+      res)))
+ ((php ruby python)
+  (let ((tmp (##inline-host-expression "gambit_scm2host(@1@)" x)))
+    (let ((res (##inline-host-expression "gambit_host2scm(@1@)" tmp)))
+      res)))
+; ((module)
+;  (let ((tmp (##inline-host-expression "Gambit_RTS.scm2host(@1@)" x)))
+;    (let ((res (##inline-host-expression "Gambit_RTS.host2scm(@1@)" tmp)))
+;      res)))
+
+ (else x))
+
+;;----------------------------------------------------------------------------
+
+;; null
+(println (if (##null? (bijective '())) "'()" ""))
+
+;; void
+(println (bijective #!void))
+
+;; boolean
+(println (bijective #t))
+(println (bijective #f))
+
+;; integer
+(println (bijective 0))
+(println (bijective -1))
+
+;; float
+(println (bijective 1.5))
+(println (bijective -1.5))
+
+;; string
+(println (bijective ""))
+(println (bijective "string"))
+
+;; array
+;(println (bijective '(1 2 3 4)))

--- a/gsc/tests/40-univ/eval.scm
+++ b/gsc/tests/40-univ/eval.scm
@@ -1,0 +1,76 @@
+(declare (extended-bindings) (not safe))
+
+(##define-macro (case-target . clauses)
+  (let ((target (if (and (pair? ##compilation-options)
+                          (pair? (car ##compilation-options)))
+                    (let ((t (assq 'target ##compilation-options)))
+                      (if t (cadr t) 'c))
+                    'c)))
+    (let loop ((clauses clauses))
+      (if (pair? clauses)
+          (let* ((clause (car clauses))
+                  (cases (car clause)))
+            (if (or (eq? cases 'else)
+                    (memq target cases))
+                `(begin ,@(cdr clause))
+                (loop (cdr clauses))))
+          `(begin)))))
+
+(##define-macro (define-target name . clauses)
+  `(define ,name (case-target ,@clauses)))
+
+(define-target num
+  ((js php python ruby) "1")
+  (else 1))
+
+(define-target str
+  ((js php python ruby) "\"a string\"")
+  (else "a string"))
+
+(define-target vd 
+  ((js) "undefined")
+  ((php) "NULL")
+  ((python) "None")
+  ((ruby) "nil")
+  (else #!void))
+
+(define-target flo
+  ((js php python ruby) "2.5")
+  (else 2.5))
+
+#;
+(define-target fn
+  ((js) "function(x) {return x}")
+  ((python) "lambda x : x")
+  ((ruby) "Proc.new {|x| x}")
+  (else (lambda (x) x)))
+
+(case-target
+ ((php)
+  (##inline-host-declaration
+"function ev($x) {
+  eval(\"\\$x=$x;\");
+  return $x;
+}"))
+ (else ""))
+
+(define-target host
+ ((js)
+  (##inline-host-expression "((typeof Gambit_RTS !== 'undefined') ? Gambit_RTS.host_function2scm : gambit_host_function2scm)(eval)"))
+ ((python)
+  (##inline-host-expression "gambit_host_function2scm(eval)")
+  #;(##inline-host-expression "Gambit_RTS.host_function2scm(eval)"))
+ ((ruby)
+  (##inline-host-expression "gambit_host_function2scm(Proc.new {|x| eval(x)})")
+  #;(##inline-host-expression "Gambit_RTS.host_function2scm(Proc.new {|x| eval(x)})"))
+ ((php)
+  (##inline-host-expression "gambit_host_function2scm(\"ev\")")
+  #;(##inline-host-expression "Gambit_RTS.host_function2scm(\"ev\")"))
+
+ (else (lambda (x) x)))
+
+(println (host num))
+(println (host flo))
+(println (host str))
+(println (host vd))
+

--- a/include/stamp.h
+++ b/include/stamp.h
@@ -2,5 +2,5 @@
  * Time stamp of last source code repository commit.
  */
 
-#define ___STAMP_YMD 20150724
-#define ___STAMP_HMS 193711
+#define ___STAMP_YMD 20150728
+#define ___STAMP_HMS 123558

--- a/include/stamp.h
+++ b/include/stamp.h
@@ -3,4 +3,4 @@
  */
 
 #define ___STAMP_YMD 20150728
-#define ___STAMP_HMS 124457
+#define ___STAMP_HMS 132818

--- a/include/stamp.h
+++ b/include/stamp.h
@@ -3,4 +3,4 @@
  */
 
 #define ___STAMP_YMD 20150728
-#define ___STAMP_HMS 123558
+#define ___STAMP_HMS 124457


### PR DESCRIPTION
Adds host2scm(_call), scm2host(_call) and the tests for those functions.

Fix a bug in emit-procedure declaration where the procedure name was used as the procedure type and the procedure type as the procedure name.

Also fix raising exception in python.

I changed my local version of univ-lib to use the general ffis instead of the Javascript versions and everything was working.

Because of the way features are added, I had to add (univ-use rtlib 'ffi) in the ##inline-host-* primitives. It seems reasonable to require ffis when dealing with inlined host code.

Note the use of rts-method-ref instead of rts-method-use in host2scm and scm2host. When using rts-method-use, the compiler hanged. I believe it is due to the circular dependency existing between those function. Anyways, host2scm and scm2host are included with univ-use-rtlib in the ffi feature.

host_function2scm creates a scheme procedure with procedure-declaration. entrypt is given as the procedure type. This seems correct to me (and the tests acknowledge it is working). 