### PR TITLE
Universal backend: Adds proper casts where needed and fixes a boxing …

### DIFF
--- a/gsc/_t-univ.scm
+++ b/gsc/_t-univ.scm
@@ -3044,7 +3044,7 @@
                                 (list (univ-field (univ-proc-name-attrib ctx)
                                                   'symbol
                                                   (lambda (ctx)
-                                                    (univ-prm-name ctx (proc-obj-name p)))
+                                                    (^cast* 'symbol (univ-prm-name ctx (proc-obj-name p))))
                                                   '(inherited))
                                       (univ-field 'ctrlpts
                                                   '(array ctrlpt)
@@ -11716,7 +11716,7 @@ tanh
 
 ;; TODO: test ##pair-mutable?
 
-(univ-define-prim-bool "##pair-mutable?" #t
+(univ-define-prim "##pair-mutable?" #t
   (make-translated-operand-generator
    (lambda (ctx return arg1)
      (return (^obj #t))))) ;; there are no immutable data (currently)
@@ -11725,7 +11725,7 @@ tanh
 
 ;; TODO: test ##subtyped-mutable?
 
-(univ-define-prim-bool "##subtyped-mutable?" #t
+(univ-define-prim "##subtyped-mutable?" #t
   (make-translated-operand-generator
    (lambda (ctx return arg1)
      (return (^obj #t))))) ;; there are no immutable data (currently)
@@ -13127,7 +13127,7 @@ tanh
    (lambda (ctx return arg1 arg2 arg3)
      (^ (^u8vector-set! arg1
                         (^fixnum-unbox arg2)
-                        (^fixnum-unbox arg3))
+                        (^cast* 'u8 (^fixnum-unbox arg3)))
         (return arg1)))))
 
 (univ-define-prim "##u8vector-shrink!" #f
@@ -13181,7 +13181,7 @@ tanh
    (lambda (ctx return arg1 arg2 arg3)
      (^ (^u16vector-set! arg1
                          (^fixnum-unbox arg2)
-                         (^fixnum-unbox arg3))
+                         (^cast* 'u16 (^fixnum-unbox arg3)))
         (return arg1)))))
 
 (univ-define-prim "##u16vector-shrink!" #f
@@ -13330,7 +13330,7 @@ tanh
    (lambda (ctx return arg1 arg2 arg3)
      (^ (^s8vector-set! arg1
                         (^fixnum-unbox arg2)
-                        (^fixnum-unbox arg3))
+                        (^cast* 's8 (^fixnum-unbox arg3)))
         (return arg1)))))
 
 (univ-define-prim "##s8vector-shrink!" #f
@@ -13384,7 +13384,7 @@ tanh
    (lambda (ctx return arg1 arg2 arg3)
      (^ (^s16vector-set! arg1
                         (^fixnum-unbox arg2)
-                        (^fixnum-unbox arg3))
+                        (^cast* 's16 (^fixnum-unbox arg3)))
         (return arg1)))))
 
 (univ-define-prim "##s16vector-shrink!" #f
@@ -13886,7 +13886,7 @@ tanh
      (return
       (^call-prim
        (^rts-method-use 'make_closure)
-       arg1
+       (^cast* 'ctrlpt arg1)
        (^fixnum-unbox arg2))))))
 
 (univ-define-prim "##closure-length" #f
@@ -14130,7 +14130,8 @@ tanh
 (univ-define-prim "##continuation-frame-set!" #t
   (make-translated-operand-generator
    (lambda (ctx return cont frame)
-     (^ (^assign (^member (^cast* 'continuation cont) 'frame) frame)
+     (^ (^assign (^member (^cast* 'continuation cont) 'frame)
+                 (^cast* 'frame frame))
         (return cont)))))
 
 (univ-define-prim "##continuation-denv" #t


### PR DESCRIPTION
## Boxing problem with `##pair-mutable?` and `##subtyped-mutable?`
`univ-define-prim-bool` introduce `^boolean-box` around the returned value so we were effectively generating `new Gambit_Boolean(true) ? new Gambit_Boolean(true) : new Gambit_Boolean(false) `. Unsurprisingly, Java isn't able to cast a `Gambit_Boolean` to `boolean` so I changed `univ-define-prim-bool` to `univ-define-prim`.

## Other changes
The other changes are simply casts added to that prevented univ-lib from compiling. 