### PR TITLE
Test for $target_os should be lowercase

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1362,7 +1362,7 @@ else
   AC_CHECK_FUNCS(hstrerror)
 
   case "$target_os" in
-    OpenBSD*)
+    openbsd*)
       # OpenBSD/mips64(el) does have get_fpc_csr(), but lacks union fpc_csr.
       ;;
     *)


### PR DESCRIPTION
This unbreaks OpenBSD/mips64 again after the spello was introduced in https://github.com/feeley/gambit/pull/29 .