### PR TITLE
Add chromium to the browser list

### DIFF
--- a/bin/gambdoc.unix.in
+++ b/bin/gambdoc.unix.in
@@ -32,7 +32,7 @@ find_browser() # sets `$exe'
   if [ "@HELP_BROWSER@" != "" ]; then
     browser_list="@HELP_BROWSER@"
   else
-    browser_list="lynx firefox mozilla netscape osascript"
+    browser_list="lynx firefox mozilla netscape osascript chrome chromium chromium-browser"
   fi
 
   browser_list="${GAMBDOC_ARG3} $browser_list"


### PR DESCRIPTION
This change allows the `help` function to use Chromium on *nix. The only difference I've noticed is that Chromium is spawned in the background and the `help` function returns immediately where Firefox (and possibly others) do not. The binary is not named uniformly across *nix. I've compiled a short list that should cover most cases.

* Arch and Debian use `chromium`
* FreeBSD uses `chrome`
* Ubuntu (and downstream) use `chromium-browser`

I'm not sure what the binary is called on OS X. Also, it probably has plain Google Chrome instead of Chromium.