### PR TITLE
Remove ws2_32 check other than MinGW

### DIFF
--- a/configure
+++ b/configure
@@ -7613,63 +7613,6 @@ if test "$ac_res" != no; then :
 fi
 
 
-               { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing WSAStartup" >&5
-$as_echo_n "checking for library containing WSAStartup... " >&6; }
-if ${ac_cv_search_WSAStartup+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  ac_func_search_save_LIBS=$LIBS
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-/* Override any GCC internal prototype to avoid an error.
-   Use char because int might match the return type of a GCC
-   builtin and then its argument prototype would still apply.  */
-#ifdef __cplusplus
-extern "C"
-#endif
-char WSAStartup ();
-int
-main ()
-{
-return WSAStartup ();
-  ;
-  return 0;
-}
-_ACEOF
-for ac_lib in '' ws2_32; do
-  if test -z "$ac_lib"; then
-    ac_res="none required"
-  else
-    ac_res=-l$ac_lib
-    LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
-  fi
-  if ac_fn_cxx_try_link "$LINENO"; then :
-  ac_cv_search_WSAStartup=$ac_res
-fi
-rm -f core conftest.err conftest.$ac_objext \
-    conftest$ac_exeext
-  if ${ac_cv_search_WSAStartup+:} false; then :
-  break
-fi
-done
-if ${ac_cv_search_WSAStartup+:} false; then :
-
-else
-  ac_cv_search_WSAStartup=no
-fi
-rm conftest.$ac_ext
-LIBS=$ac_func_search_save_LIBS
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_WSAStartup" >&5
-$as_echo "$ac_cv_search_WSAStartup" >&6; }
-ac_res=$ac_cv_search_WSAStartup
-if test "$ac_res" != no; then :
-  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
-
-fi
-
-
                { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing clock_gettime" >&5
 $as_echo_n "checking for library containing clock_gettime... " >&6; }
 if ${ac_cv_search_clock_gettime+:} false; then :

--- a/configure.ac
+++ b/configure.ac
@@ -1246,8 +1246,6 @@ else
 
                AC_SEARCH_LIBS(openpty,util)
 
-               AC_SEARCH_LIBS(WSAStartup,ws2_32)
-
                AC_SEARCH_LIBS(clock_gettime,rt)
 
                AC_SEARCH_LIBS(timeBeginPeriod,winmm)


### PR DESCRIPTION
Do not link against Winsock2(ws2_32) to prevent conflict with Cygwin libc.

Should fix #99.

We can also remove
```
               AC_SEARCH_LIBS(timeBeginPeriod,winmm)
```
and
```
  AC_CHECK_HEADERS(ws2tcpip.h)
```
but these are not blocker for building on Cygwin.