### PR TITLE
Disable nanosleep() on os_io.c for Cygwin

### DIFF
--- a/lib/os.h
+++ b/lib/os.h
@@ -275,7 +275,14 @@
 #endif
 
 #endif
+#ifdef __CYGWIN__
+/*
+ * Cygwin 2.4.1 x86_64 would return ECHILD during nanosleep().
+ * Avoid it during I/O wait.
+ */
+#define USE_CYGWIN_NANOSLEEP_WORKAROUND
 
+#endif
 
 #ifdef USE_WIN32
 

--- a/lib/os_io.c
+++ b/lib/os_io.c
@@ -1029,7 +1029,7 @@ ___time timeout;)
 
             goto select_done;
           }
-#ifdef USE_nanosleep
+#if defined(USE_nanosleep) && !defined(USE_CYGWIN_NANOSLEEP_WORKAROUND)
         else
           {
 


### PR DESCRIPTION
It seems nanosleep() may return ECHILD on Cygwin x86_64.

Cygwin build can be fixed with #191 and it would produce working `gsi` but to make test passing, we have to do this patch..

This patch make `make check` pass on Cygwin 2.4.1 x86_64.