### PR TITLE
Save and restore errno in sigchld_signal_handler

### DIFF
--- a/lib/os_io.c
+++ b/lib/os_io.c
@@ -9405,6 +9405,7 @@ ___HIDDEN void sigchld_signal_handler
         (sig)
 int sig;)
 {
+  int save_errno = errno;
 #ifdef USE_signal
   ___set_signal_handler (SIGCHLD, sigchld_signal_handler);
 #endif
@@ -9456,6 +9457,7 @@ int sig;)
             } while  (d != head);
         }
     }
+  errno = save_errno;
 }
 
 #endif


### PR DESCRIPTION
Save and restore errno in sigchld_signal_handler, just same as the example on POSIX document
http://pubs.opengroup.org/onlinepubs/9699919799/functions/wait.html#tag_16_645_06_02

It seems Cygwin invokes signal handler just *after* setting `errno` for in-flight syscall (in #99 case, `nanosleep`) unlike other implementations. Thus, `EINTR` code for `nanosleep` always get overridden with `ECHILD` of `waitpid` call inside `sigchld_signal_handler`.

This patch essentially adds TLS access as `errno` load and store for each `sigchld_signal_handler` invocation. I don't think it would affect any of performance.

It fixes `make check` on Cygwin.