### PR TITLE
Fix issue #109, always use getter/setter to access thread local processor state.

### DIFF
--- a/include/gambit.h.in
+++ b/include/gambit.h.in
@@ -5376,22 +5376,16 @@ if (___TYP((___temp=(src)))==___tSUBTYPED&&___SUBTYPE(___temp)==___FIX(___sPROMI
 
 #ifdef ___THREAD_LOCAL_STORAGE_CLASS
 
-/* Use thread local storage class (this is probably fast) */
-
 extern ___THREAD_LOCAL_STORAGE_CLASS void *___tls_ptr;
 
 #define ___FAST_GET_PSTATE
-#define ___GET_PSTATE() ___CAST(___processor_state,___tls_ptr)
-#define ___SET_PSTATE(ps) ___tls_ptr = ___CAST(void*,ps)
 
-#else
+#endif
 
-/* Use thread local storage getter/setter (this is probably slow) */
+/* Always use getter/setter to access thread local storage */
 
 #define ___GET_PSTATE() ___CAST(___processor_state,___get_tls_ptr())
 #define ___SET_PSTATE(ps) ___set_tls_ptr(___CAST(void*,ps))
-
-#endif
 
 #endif
 
@@ -9565,12 +9559,10 @@ typedef struct ___global_state_struct
        ___P((___WORD volatile *ptr),
             ());
 #endif
-#ifndef ___THREAD_LOCAL_STORAGE_CLASS
     void *(*___get_tls_ptr) ___PVOID;
     void (*___set_tls_ptr)
        ___P((void *ptr),
             ());
-#endif
     void (*___disable_heartbeat_interrupts) ___PVOID;
     void (*___enable_heartbeat_interrupts) ___PVOID;
 #endif
@@ -10869,12 +10861,10 @@ ___IMP_FUNC(___WORD,___emulated_fetch_and_clear_word)
    ___P((___WORD volatile *ptr),
         ());
 #endif
-#ifndef ___THREAD_LOCAL_STORAGE_CLASS
 ___IMP_FUNC(void *,___get_tls_ptr) ___PVOID;
 ___IMP_FUNC(void,___set_tls_ptr)
    ___P((void *ptr),
         ());
-#endif
 #endif
 
 #ifndef ___INCLUDED_FROM_OS_TIME

--- a/lib/mem.c
+++ b/lib/mem.c
@@ -1122,6 +1122,7 @@ ___SCMOBJ ___find_global_var_bound_to
         (val)
 ___SCMOBJ val;)
 {
+  ___processor_state ___ps = ___PSTATE;
   ___SCMOBJ sym = ___NUL;
   int i;
 

--- a/lib/os_thread.c
+++ b/lib/os_thread.c
@@ -287,15 +287,19 @@ ___WORD volatile *ptr;)
 
 #ifdef ___THREAD_LOCAL_STORAGE_CLASS
 
-
 ___THREAD_LOCAL_STORAGE_CLASS void *___tls_ptr;
 
-
-#else
+#endif
 
 
 void *___get_tls_ptr ___PVOID
 {
+#ifdef ___THREAD_LOCAL_STORAGE_CLASS
+
+  return ___tls_ptr;
+
+#else
+
 #ifdef ___USE_POSIX_THREAD_SYSTEM
 
   return pthread_getspecific (___thread_mod.tls_ptr_key); /* ignore error */
@@ -315,6 +319,8 @@ void *___get_tls_ptr ___PVOID
 
 #endif
 #endif
+
+#endif
 }
 
 void ___set_tls_ptr
@@ -322,6 +328,12 @@ void ___set_tls_ptr
         (ptr)
 void *ptr;)
 {
+#ifdef ___THREAD_LOCAL_STORAGE_CLASS
+
+  ___tls_ptr = ptr;
+
+#else
+
 #ifdef ___USE_POSIX_THREAD_SYSTEM
 
   pthread_setspecific (___thread_mod.tls_ptr_key, ptr); /* ignore error */
@@ -341,10 +353,9 @@ void *ptr;)
 
 #endif
 #endif
-}
-
 
 #endif
+}
 
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
Fix issue #109, use getter/setter to access tls_ptr, thus avoid linking external TLS variable.

To remove the minimal overhead of using a getter when TLS is supported, ___GET_PSTATE() could have an internal definition (i.e. when compiling the gambit library).